### PR TITLE
Encoding NSString

### DIFF
--- a/JSONKit.h
+++ b/JSONKit.h
@@ -231,6 +231,10 @@ typedef JKFlags JKSerializeOptionFlags;
 - (id)objectFromJSONString;
 - (id)objectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
 - (id)objectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error;
+- (NSData *)JSONData;
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error;
+- (NSString *)JSONString;
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error;
 @end
 
 @interface NSData (JSONKit)

--- a/JSONKit.m
+++ b/JSONKit.m
@@ -1496,6 +1496,26 @@ static id json_parse_it(JKParseState *parseState) {
   return([[JSONDecoder decoderWithParseOptions:parseOptionFlags] parseUTF8String:utf8String length:utf8Length error:error]);
 }
 
+- (NSData *)JSONData
+{
+	return([self JSONDataWithOptions:JKSerializeOptionNone error:NULL]);
+}
+
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error
+{
+	return(jk_encode(self, serializeOptions, error));
+}
+
+- (NSString *)JSONString
+{
+	return([self JSONStringWithOptions:JKSerializeOptionNone error:NULL]);
+}
+
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error
+{
+	return([[[NSString alloc] initWithData:[self JSONDataWithOptions:serializeOptions error:error] encoding:NSUTF8StringEncoding] autorelease]);
+}
+
 @end
 
 @implementation NSData (JSONKit)


### PR DESCRIPTION
It's useful to be able to encode NSString directly, for example when building a JavaScript string to send to a UIWebView using -[UIWebView stringByEvaluatingJavaScriptFromString:].

I copied the encoding methods found in the NSDictionary/NSArray categories into the NSString category. A simple test suggest it works, but I am very new to JSONKit so if I've overlooked something I apologize. :-)
