### PR TITLE
Here are some small changes I did - see if you find them useful :)

### DIFF
--- a/JSONKit.m
+++ b/JSONKit.m
@@ -651,9 +651,8 @@ void jk_collectionClassLoadTimeInitialization(void) {
   id temp_NSNumber = [NSNumber alloc];
   _jk_NSNumberInitWithUnsignedLongLongImp = (NSNumberInitWithUnsignedLongLongImp)[temp_NSNumber methodForSelector:@selector(initWithUnsignedLongLong:)];
   [[temp_NSNumber init] release];
-  temp_NSNumber = NULL;
   
-  [pool release]; pool = NULL;
+  [pool release];
 }
 
 
@@ -718,8 +717,7 @@ static void _JKArrayRemoveObjectAtIndex(JKArray *array, NSUInteger objectIndex) 
   if(!((array != NULL) && (array->objects != NULL) && (objectIndex < array->count) && (array->objects[objectIndex] != NULL))) { return; }
   CFRelease(array->objects[objectIndex]);
   array->objects[objectIndex] = NULL;
-  if((objectIndex + 1UL) < array->count) { memmove(&array->objects[objectIndex], &array->objects[objectIndex + 1UL], sizeof(id) * ((array->count - 1UL) - objectIndex)); array->objects[array->count] = NULL; }
-  array->count--;
+  if((objectIndex + 1UL) < array->count) { memmove(&array->objects[objectIndex], &array->objects[objectIndex + 1UL], sizeof(id) * ((array->count - 1UL) - objectIndex)); array->objects[--(array->count)] = NULL; }
 }
 
 - (void)dealloc


### PR DESCRIPTION
Fixed nullyfyng of the last slot of array->objects on removal of an object

When an object at objectIndex is removed in `_JKArrayRemoveObjectAtIndex(JKArray *, NSUInteger)` the last slot of `array->objects` should be set to `NULL` which is `array->objects[array->count - 1UL]``and not``array->objects[array->count]``.
Also I see no point in setting``temp_NSNumber``and``pool``to``NULL``. It doesn't hurt anyone but why compile instructions which have a "NULL" effect :)
