### PR TITLE
Surpress "multiple methods named" error

### DIFF
--- a/JSONKit.m
+++ b/JSONKit.m
@@ -848,7 +848,7 @@ static void _JKArrayRemoveObjectAtIndex(JKArray *array, NSUInteger objectIndex) 
 - (NSArray *)allObjects
 {
   NSParameterAssert(collection != NULL);
-  NSUInteger count = [collection count], atObject = 0UL;
+  NSUInteger count = [(NSArray *)collection count], atObject = 0UL;
   id         objects[count];
 
   while((objects[atObject] = [self nextObject]) != NULL) { NSParameterAssert(atObject < count); atObject++; }

--- a/JSONKit.m
+++ b/JSONKit.m
@@ -848,7 +848,7 @@ static void _JKArrayRemoveObjectAtIndex(JKArray *array, NSUInteger objectIndex) 
 - (NSArray *)allObjects
 {
   NSParameterAssert(collection != NULL);
-  NSUInteger count = [(NSArray *)collection count], atObject = 0UL;
+  NSUInteger count = [(NSDictionary *)collection count], atObject = 0UL;
   id         objects[count];
 
   while((objects[atObject] = [self nextObject]) != NULL) { NSParameterAssert(atObject < count); atObject++; }


### PR DESCRIPTION
I realize that `collection` won't always be an NSArray, but the cast will let the compiler know to expect a NSUInteger return type instead of `size_t` which is also a return type a method named `count` inside of JSONKit.
