### PR TITLE
Add CocoaPods spec.

### DIFF
--- a/JSONKit.podspec
+++ b/JSONKit.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name     = 'JSONKit'
+  s.version  = '1.4'
+  s.license  = 'BSD / Apache License, Version 2.0'
+  s.summary  = 'A Very High Performance Objective-C JSON Library.'
+  s.homepage = 'https://github.com/johnezang/JSONKit'
+  s.author   = 'John Engelhart'
+  s.source   = { :git => 'https://github.com/johnezang/JSONKit.git', :tag => 'v1.4' }
+
+  s.source_files = 'JSONKit.*'
+end


### PR DESCRIPTION
I have added JSONKit to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager a while ago.

I didn’t see any planned milestones, but I was wondering if you were planning on releasing v1.5 in the near future? Because there are other libraries which vendor versions of JSONKit newer than the v1.4 tag, which means I can’t make them depend on the v1.4 version for which we have [a spec](https://github.com/CocoaPods/Specs/blob/master/JSONKit/1.4/JSONKit.podspec).

Finally, this pull request adds the pod spec to the repo as well. Adding this will allow users to install an unreleased version directly from your repo. It also allows you to more easily keep the spec up-to-date with any possible changes, instead of having to remember it all when releasing a new version.

Thanks!
