### PR TITLE
Added parse option JKParseOptionNormalizeOnNull

### DIFF
--- a/JSONKit.h
+++ b/JSONKit.h
@@ -121,7 +121,8 @@ enum {
   JKParseOptionUnicodeNewlines          = (1 << 1),
   JKParseOptionLooseUnicode             = (1 << 2),
   JKParseOptionPermitTextAfterValidJSON = (1 << 3),
-  JKParseOptionValidFlags               = (JKParseOptionComments | JKParseOptionUnicodeNewlines | JKParseOptionLooseUnicode | JKParseOptionPermitTextAfterValidJSON),
+  JKParseOptionNormalizeOnNull			= (1 << 4),
+  JKParseOptionValidFlags               = (JKParseOptionComments | JKParseOptionUnicodeNewlines | JKParseOptionLooseUnicode | JKParseOptionPermitTextAfterValidJSON | JKParseOptionNormalizeOnNull),
 };
 typedef JKFlags JKParseOptionFlags;
 

--- a/JSONKit.m
+++ b/JSONKit.m
@@ -2065,7 +2065,7 @@ static void *jk_object_for_token(JKParseState *parseState) {
     case JKTokenTypeArrayBegin:  parsedAtom = jk_parse_array(parseState);      break;
     case JKTokenTypeTrue:        parsedAtom = (void *)kCFBooleanTrue;          break;
     case JKTokenTypeFalse:       parsedAtom = (void *)kCFBooleanFalse;         break;
-    case JKTokenTypeNull:        parsedAtom = (void *)kCFNull;                 break;
+	case JKTokenTypeNull:        parsedAtom = ((parseState->parseOptionFlags & JKParseOptionNormalizeOnNull) ? (void *)CFSTR("") : (void *)kCFNull);                 break;
     default: jk_error(parseState, @"Internal error: Unknown token type. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); break;
   }
   

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ String             | [`NSString`][NSString]
 Array              | [`NSArray`][NSArray]
 Object             | [`NSDictionary`][NSDictionary]
 
+**Warning:** `null` will be an empty string if `JKParseOptionNormalizeOnNull` is used.
+
 JSONKit uses Core Foundation internally, and it is assumed that Core Foundation &equiv; Foundation for every equivalent base type, i.e. [`CFString`][CFString] &equiv; [`NSString`][NSString].
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119][].
@@ -221,6 +223,7 @@ The <code>objectWith&hellip;</code> methods return immutable collection objects 
   <tr><td valign="top"><code>JKParseOptionUnicodeNewlines</code></td><td>Allow Unicode recommended <code>(?:\r\n|[\n\v\f\r\x85\p{Zl}\p{Zp}])</code> newlines in JSON.  The <a href="http://tools.ietf.org/html/rfc4627">JSON specification</a> only allows the newline characters <code>\r</code> and <code>\n</code>, but this option allows JSON that contains the <a href="http://en.wikipedia.org/wiki/Newline#Unicode">Unicode recommended newline characters</a> to be parsed.  JSON that contains these additional newline characters is not strictly conforming JSON.</td></tr>
   <tr><td valign="top"><code>JKParseOptionLooseUnicode</code></td><td>Normally the decoder will stop with an error at any malformed Unicode. This option allows JSON with malformed Unicode to be parsed without reporting an error. Any malformed Unicode is replaced with <code>\uFFFD</code>, or <code>REPLACEMENT CHARACTER</code>, as specified in <a href="http://www.unicode.org/versions/Unicode6.0.0/ch03.pdf">The Unicode 6.0 standard, Chapter 3</a>, section 3.9 <em>Unicode Encoding Forms</em>.</td></tr>
   <tr><td valign="top"><code>JKParseOptionPermitTextAfterValidJSON</code></td><td>Normally, <code>non-white-space</code> that follows the JSON is interpreted as a parsing failure. This option allows for any trailing <code>non-white-space</code> to be ignored and not cause a parsing error.</td></tr>
+  <tr><td valign="top"><code>JKParseOptionNormalizeOnNull</code></td><td>Use an empty string instead of NSNull class on `null` value.</td></tr>
 </table>
 
 ### Serializing Interface


### PR DESCRIPTION
Added parse option JKParseOptionNormalizeOnNull to use an empty string
instead of NSNull class on `null` value.

A client's API return a JSON with 'null' values on server error, so to avoid app crashes while expecting a string, I'm using this new flag.
