### PR TITLE
Fixed compiler warning of LLVM 4.0

### DIFF
--- a/JSONKit.m
+++ b/JSONKit.m
@@ -103,6 +103,7 @@
 #include <string.h>
 #include <assert.h>
 #include <sys/errno.h>
+#include <cmath>
 #include <math.h>
 #include <limits.h>
 #include <objc/runtime.h>


### PR DESCRIPTION
Included <cmath>, as the LLVM 4.0 compiler was complaining about std:

" Use of undeclared identifier 'std' "
