### PR TITLE
Renamed JSONDecoder to JKJSONDecoder to resolve class conflicts when using -all_load compiler flag

### DIFF
--- a/JSONKit.h
+++ b/JSONKit.h
@@ -140,7 +140,7 @@ typedef struct JKParseState JKParseState; // Opaque internal, private type.
 
 // As a general rule of thumb, if you use a method that doesn't accept a JKParseOptionFlags argument, it defaults to JKParseOptionStrict
 
-@interface JSONDecoder : NSObject {
+@interface JKJSONDecoder : NSObject {
   JKParseState *parseState;
 }
 + (id)decoder;

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Fork of JSONKit to reslove potential namespace conflicts with the ```JSONDecoder``` Object.  Renamed to ```JKJSONDecoder```
+
 # JSONKit
 
 JSONKit is dual licensed under either the terms of the BSD License, or alternatively under the terms of the Apache License, Version 2.0.<br />


### PR DESCRIPTION
Hi, great project! I've been using it as part of a static library(https://github.com/tapit/TapIt-iPhone-SDK), and  have had some complaints from users of naming conflicts with other json libraries.  My fix was to prepend JK to JSONDecoder.  Not sure if it will cause any backwards compatibility issues w/ your users, but if not, feel free to push so I can drop my fork and go straight to the source!
