### PR TITLE
Silencing clang warning "deprecated-objc-isa-usage"

### DIFF
--- a/JSONKit.m
+++ b/JSONKit.m
@@ -677,7 +677,10 @@ static JKArray *_JKArrayCreate(id *objects, NSUInteger count, BOOL mutableCollec
   NSCParameterAssert((objects != NULL) && (_JKArrayClass != NULL) && (_JKArrayInstanceSize > 0UL));
   JKArray *array = NULL;
   if(JK_EXPECT_T((array = (JKArray *)calloc(1UL, _JKArrayInstanceSize)) != NULL)) { // Directly allocate the JKArray instance via calloc.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-objc-isa-usage"
     array->isa      = _JKArrayClass;
+#pragma clang diagnostic pop
     if((array = [array init]) == NULL) { return(NULL); }
     array->capacity = count;
     array->count    = count;
@@ -928,7 +931,10 @@ static JKDictionary *_JKDictionaryCreate(id *keys, NSUInteger *keyHashes, id *ob
   NSCParameterAssert((keys != NULL) && (keyHashes != NULL) && (objects != NULL) && (_JKDictionaryClass != NULL) && (_JKDictionaryInstanceSize > 0UL));
   JKDictionary *dictionary = NULL;
   if(JK_EXPECT_T((dictionary = (JKDictionary *)calloc(1UL, _JKDictionaryInstanceSize)) != NULL)) { // Directly allocate the JKDictionary instance via calloc.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-objc-isa-usage"
     dictionary->isa      = _JKDictionaryClass;
+#pragma clang diagnostic pop
     if((dictionary = [dictionary init]) == NULL) { return(NULL); }
     dictionary->capacity = _JKDictionaryCapacityForCount(count);
     dictionary->count    = 0UL;

--- a/JSONKit.m
+++ b/JSONKit.m
@@ -223,6 +223,10 @@
 #endif // defined (__GNUC__) && (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
 
 
+struct objc_object_without_isa_warning {
+    Class isa;
+};
+
 @class JKArray, JKDictionaryEnumerator, JKDictionary;
 
 enum {
@@ -664,6 +668,7 @@ void jk_collectionClassLoadTimeInitialization(void) {
 }
 @end
 
+
 @implementation JKArray
 
 + (id)allocWithZone:(NSZone *)zone
@@ -677,10 +682,7 @@ static JKArray *_JKArrayCreate(id *objects, NSUInteger count, BOOL mutableCollec
   NSCParameterAssert((objects != NULL) && (_JKArrayClass != NULL) && (_JKArrayInstanceSize > 0UL));
   JKArray *array = NULL;
   if(JK_EXPECT_T((array = (JKArray *)calloc(1UL, _JKArrayInstanceSize)) != NULL)) { // Directly allocate the JKArray instance via calloc.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-objc-isa-usage"
-    array->isa      = _JKArrayClass;
-#pragma clang diagnostic pop
+    ((struct objc_object_without_isa_warning*)array)->isa = _JKArrayClass;
     if((array = [array init]) == NULL) { return(NULL); }
     array->capacity = count;
     array->count    = count;
@@ -931,10 +933,7 @@ static JKDictionary *_JKDictionaryCreate(id *keys, NSUInteger *keyHashes, id *ob
   NSCParameterAssert((keys != NULL) && (keyHashes != NULL) && (objects != NULL) && (_JKDictionaryClass != NULL) && (_JKDictionaryInstanceSize > 0UL));
   JKDictionary *dictionary = NULL;
   if(JK_EXPECT_T((dictionary = (JKDictionary *)calloc(1UL, _JKDictionaryInstanceSize)) != NULL)) { // Directly allocate the JKDictionary instance via calloc.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-objc-isa-usage"
-    dictionary->isa      = _JKDictionaryClass;
-#pragma clang diagnostic pop
+    ((struct objc_object_without_isa_warning*)dictionary)->isa      = _JKDictionaryClass;
     if((dictionary = [dictionary init]) == NULL) { return(NULL); }
     dictionary->capacity = _JKDictionaryCapacityForCount(count);
     dictionary->count    = 0UL;

--- a/JSONKit.m
+++ b/JSONKit.m
@@ -2601,7 +2601,8 @@ static int jk_encode_add_atom_to_buffer(JKEncodeState *encodeState, void *object
   // XXX XXX XXX XXX
 
 
-  BOOL   workAroundMacOSXABIBreakingBug = (JK_EXPECT_F(((NSUInteger)object) & 0x1))     ? YES  : NO;
+  register int obj = (int)object;
+  BOOL   workAroundMacOSXABIBreakingBug = (JK_EXPECT_F(obj & 0x1))     ? YES  : NO;
   void  *objectISA                      = (JK_EXPECT_F(workAroundMacOSXABIBreakingBug)) ? NULL : *((void **)objectPtr);
   if(JK_EXPECT_F(workAroundMacOSXABIBreakingBug)) { goto slowClassLookup; }
 


### PR DESCRIPTION
Assigning dictionary->isa = _JKDictionaryClass is fast and safe, but produces a noisy warning.

I propose suppressing this warning with #pragma clang diagnostic ignored "-Wdeprecated-objc-isa-usage"
