### PR TITLE
Repair JSONKit.m file appears in the iOS 6.0 or later version of warning.

### DIFF
--- a/JSONKit.m
+++ b/JSONKit.m
@@ -677,7 +677,8 @@ static JKArray *_JKArrayCreate(id *objects, NSUInteger count, BOOL mutableCollec
   NSCParameterAssert((objects != NULL) && (_JKArrayClass != NULL) && (_JKArrayInstanceSize > 0UL));
   JKArray *array = NULL;
   if(JK_EXPECT_T((array = (JKArray *)calloc(1UL, _JKArrayInstanceSize)) != NULL)) { // Directly allocate the JKArray instance via calloc.
-    array->isa      = _JKArrayClass;
+    //array->isa      = _JKArrayClass;
+    object_setClass(array,_JKArrayClass);
     if((array = [array init]) == NULL) { return(NULL); }
     array->capacity = count;
     array->count    = count;
@@ -928,7 +929,8 @@ static JKDictionary *_JKDictionaryCreate(id *keys, NSUInteger *keyHashes, id *ob
   NSCParameterAssert((keys != NULL) && (keyHashes != NULL) && (objects != NULL) && (_JKDictionaryClass != NULL) && (_JKDictionaryInstanceSize > 0UL));
   JKDictionary *dictionary = NULL;
   if(JK_EXPECT_T((dictionary = (JKDictionary *)calloc(1UL, _JKDictionaryInstanceSize)) != NULL)) { // Directly allocate the JKDictionary instance via calloc.
-    dictionary->isa      = _JKDictionaryClass;
+    //dictionary->isa      = _JKDictionaryClass;
+    object_setClass(dictionary,_JKDictionaryClass);
     if((dictionary = [dictionary init]) == NULL) { return(NULL); }
     dictionary->capacity = _JKDictionaryCapacityForCount(count);
     dictionary->count    = 0UL;


### PR DESCRIPTION
The warning at iOS 6.0 or later.
-    array->isa      = _JKArrayClass;
-    object_setClass(array,_JKArrayClass);
-    dictionary->isa      = _JKDictionaryClass;
-    object_setClass(dictionary,_JKDictionaryClass);
