### PR TITLE
Improving clearCache and mutableObjectFromJSONDataWithParseOptions: performance.

### DIFF
--- a/JSONKit.m
+++ b/JSONKit.m
@@ -2145,11 +2145,11 @@ static void _JSONDecoderCleanup(JSONDecoder *decoder) {
     if(JK_EXPECT_T(parseState->cache.items != NULL)) {
       size_t idx = 0UL;
       for(idx = 0UL; idx < parseState->cache.count; idx++) {
-        if(JK_EXPECT_T(parseState->cache.items[idx].object != NULL)) { CFRelease(parseState->cache.items[idx].object); parseState->cache.items[idx].object = NULL; }
-        if(JK_EXPECT_T(parseState->cache.items[idx].bytes  != NULL)) { free(parseState->cache.items[idx].bytes);       parseState->cache.items[idx].bytes  = NULL; }
-        memset(&parseState->cache.items[idx], 0, sizeof(JKTokenCacheItem));
+        if(JK_EXPECT_T(parseState->cache.items[idx].object != NULL)) { CFRelease(parseState->cache.items[idx].object); }
+        if(JK_EXPECT_T(parseState->cache.items[idx].bytes  != NULL)) { free(parseState->cache.items[idx].bytes); }
         parseState->cache.age[idx] = 0U;
       }
+      memset(parseState->cache.items, 0, parseState->cache.count * sizeof(JKTokenCacheItem));
     }
   }
 }


### PR DESCRIPTION
Replacing 1024 memset calls with a single call.

clearCache before:
![clearCache before](http://i.agilebits.com/rk/clearCache_before_173D8050.png)

clearCache after:
![clearCache after](http://i.agilebits.com/rk/clearCache_after_173D801D.png)

mutableObjectFromJSONDataWithParseOptions before
![mutableObjectFromJSONDataWithParseOptions before](http://i.agilebits.com/rk/mutableObjectFromJSONDataWithParseOptions_before_173D8193.png)

mutableObjectFromJSONDataWithParseOptions after
![mutableObjectFromJSONDataWithParseOptions after](http://i.agilebits.com/rk/mutableObjectFromJSONDataWithParseOptions_after_173D80D5.png)
