### PR TITLE
Suppress CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS

### DIFF
--- a/JSONKit.m
+++ b/JSONKit.m
@@ -2203,6 +2203,11 @@ static id _JKParseUTF8String(JKParseState *parseState, BOOL mutableCollections, 
 #pragma mark Deprecated as of v1.4
 ////////////
 
+// The implementation of these deprecated methods is intentional, since JSONKit is
+// the one who declares them deprecated! So, suppress that particular compiler warning
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
 // Deprecated in JSONKit v1.4.  Use objectWithUTF8String:length: instead.
 - (id)parseUTF8String:(const unsigned char *)string length:(size_t)length
 {
@@ -2226,6 +2231,8 @@ static id _JKParseUTF8String(JKParseState *parseState, BOOL mutableCollections, 
 {
   return([self objectWithData:jsonData error:error]);
 }
+
+#pragma clang diagnostic pop
 
 ////////////
 #pragma mark Methods that return immutable collection objects


### PR DESCRIPTION
We've recently turned this on in a project, and wish to suppress JSONKit from warning about this.
