### PR TITLE
Optionally allow numeric over- and under-flows

### DIFF
--- a/JSONKit.h
+++ b/JSONKit.h
@@ -121,7 +121,8 @@ enum {
   JKParseOptionUnicodeNewlines          = (1 << 1),
   JKParseOptionLooseUnicode             = (1 << 2),
   JKParseOptionPermitTextAfterValidJSON = (1 << 3),
-  JKParseOptionValidFlags               = (JKParseOptionComments | JKParseOptionUnicodeNewlines | JKParseOptionLooseUnicode | JKParseOptionPermitTextAfterValidJSON),
+  JKParseOptionTruncateNumbers          = (1 << 4),
+  JKParseOptionValidFlags               = (JKParseOptionComments | JKParseOptionUnicodeNewlines | JKParseOptionLooseUnicode | JKParseOptionPermitTextAfterValidJSON | JKParseOptionTruncateNumbers),
 };
 typedef JKFlags JKParseOptionFlags;
 

--- a/JSONKit.m
+++ b/JSONKit.m
@@ -1699,13 +1699,13 @@ static int jk_parse_number(JKParseState *parseState) {
     }
 
     if(JK_EXPECT_F(errno != 0)) {
-      numberState = JSONNumberStateError;
       if(errno == ERANGE) {
         switch(parseState->token.value.type) {
-          case JKValueTypeDouble:           jk_error(parseState, @"The value '%s' could not be represented as a 'double' due to %s.",           numberTempBuf, (parseState->token.value.number.doubleValue == 0.0) ? "underflow" : "overflow"); break; // see above for == 0.0.
-          case JKValueTypeLongLong:         jk_error(parseState, @"The value '%s' exceeded the minimum value that could be represented: %lld.", numberTempBuf, parseState->token.value.number.longLongValue);                                   break;
-          case JKValueTypeUnsignedLongLong: jk_error(parseState, @"The value '%s' exceeded the maximum value that could be represented: %llu.", numberTempBuf, parseState->token.value.number.unsignedLongLongValue);                           break;
-          default:                          jk_error(parseState, @"Internal error: Unknown token value type. %@ line #%ld",                     [NSString stringWithUTF8String:__FILE__], (long)__LINE__);                                      break;
+          case JKValueTypeDouble: if(!(parseState->parseOptionFlags & JKParseOptionTruncateNumbers)) { numberState = JSONNumberStateError; jk_error(parseState, @"The value '%s' could not be represented as a 'double' due to %s.",           numberTempBuf, (parseState->token.value.number.doubleValue == 0.0) ? "underflow" : "overflow"); } break; // see above for == 0.0.
+          case JKValueTypeLongLong: if(!(parseState->parseOptionFlags & JKParseOptionTruncateNumbers)) { numberState = JSONNumberStateError; jk_error(parseState, @"The value '%s' exceeded the minimum value that could be represented: %lld.", numberTempBuf, parseState->token.value.number.longLongValue); } break;
+          case JKValueTypeUnsignedLongLong: if(!(parseState->parseOptionFlags & JKParseOptionTruncateNumbers)) { numberState = JSONNumberStateError; jk_error(parseState, @"The value '%s' exceeded the maximum value that could be represented: %llu.", numberTempBuf, parseState->token.value.number.unsignedLongLongValue); } break;
+          default:
+              numberState = JSONNumberStateError; jk_error(parseState, @"Internal error: Unknown token value type. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); break;
         }
       }
     }


### PR DESCRIPTION
Although JSON specification does not set any limits on how large
(or small) JSON numeric values can be, JSONKit throws an error
when it encounters numbers that are too large to represent on a
given system. This is may be an undesirable behavior when dealing 
with some web-service providers that may, for example, return very 
large TTL values (to represent non-expiring timestamps) or metrics 
that are very close to zero and could be easily represented as such.

JKParseOptionTruncateNumbers is a parse option introduced here that,
when set, causes parser to ignore overflow-related numeric errors.
When this option is not set, the parser behaves in a normal way.
